### PR TITLE
Solution

### DIFF
--- a/cleanLogFiles.sh
+++ b/cleanLogFiles.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# clean build too with: gradle clean
+rm -rf ./src/main/resources/generated/logs && rm ./final.log && rm ./final-gnu.log

--- a/easierSolution.sh
+++ b/easierSolution.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sort ./src/main/resources/generated/logs/* > final-gnu.log

--- a/runJar.sh
+++ b/runJar.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# run this after: gradle build
+
+java -jar -Xmx34m ./build/libs/logAggregation-0.0.1-SNAPSHOT.jar

--- a/src/main/java/com/armory/logsort/FileHandler.java
+++ b/src/main/java/com/armory/logsort/FileHandler.java
@@ -1,0 +1,38 @@
+package com.armory.logsort;
+import java.io.*;
+
+
+public class FileHandler {
+    private FileReader fReader ;
+    private BufferedReader bReader ;
+    public File file ;
+
+    public FileHandler(File file){
+        try {
+            final FileReader fReader = new FileReader(file);
+            final BufferedReader bReader = new BufferedReader(fReader);
+            this.fReader = fReader;
+            this.bReader = bReader;
+            this.file = file;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public String readLine(){
+        try {
+            final String line = this.bReader.readLine();
+            return line;// possible null
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public String readDate(){ // unused
+        final String line = this.readLine();
+        if(line == null) return null;
+        final String date = line.substring(0, line.indexOf(","));
+        return date;
+    }
+}

--- a/src/main/java/com/armory/logsort/HeapInterface.java
+++ b/src/main/java/com/armory/logsort/HeapInterface.java
@@ -1,0 +1,10 @@
+package com.armory.logsort;
+
+public class HeapInterface {
+    final public FileHandler fh;
+    final public String line;
+    public HeapInterface(FileHandler fh, String line){
+    this.fh = fh;
+    this.line = line;
+    }
+}

--- a/src/main/java/com/armory/logsort/LogSortApplication.java
+++ b/src/main/java/com/armory/logsort/LogSortApplication.java
@@ -4,6 +4,7 @@ import com.armory.logsort.generator.LogGenerator;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -13,14 +14,46 @@ public class LogSortApplication {
 
     public static void main(String[] args) {
         // generate log files
-        new LogGenerator(100, 100).generate("./src/main/resources/generated/logs/");
+        // commented to test without generating the files
+        new LogGenerator(1000, 1000).generate("./src/main/resources/generated/logs/");
+        // these params generate around 47 MB of files
 
         // read log files
         final List<File> logFiles = Arrays.asList(new File("./src/main/resources/generated/logs/").listFiles());
 
         final Instant start = Instant.now();
 
-        new LogPrinter().printLogs(logFiles);
+        final MaxHeap heap = new MaxHeap();
+
+        for (File file : logFiles){
+                final FileHandler fh = new FileHandler(file);
+                heap.add(fh);
+        }
+        final Object[] arr = heap.prq.toArray();
+        System.out.println("arr " + arr.length);
+        try {
+                FileWriter fw = new FileWriter("final.log");
+                fw.flush(); //empty it
+        String line = null;
+        do {
+                line = heap.pop();
+                if(line == null) continue;
+                try {
+                        fw.write(line + "\n");
+                } catch (Exception e) {
+                        e.printStackTrace();
+                        return;
+                }
+                // persist date
+                // print out or file
+        } while(line != null);
+        fw.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return;
+        }
+
+        // new LogPrinter().printLogs(logFiles);
 
         final Instant finish = Instant.now();
         System.out.println("\nLog sorting and printing took: " + (finish.toEpochMilli() - start.toEpochMilli()) + "ms");

--- a/src/main/java/com/armory/logsort/MaxHeap.java
+++ b/src/main/java/com/armory/logsort/MaxHeap.java
@@ -1,0 +1,44 @@
+package com.armory.logsort;
+import java.io.*;
+import java.util.PriorityQueue;
+
+// I guess this is actually a MinHeap, but lets leave
+// the naming like this for now...
+public class MaxHeap {
+    public PriorityQueue<HeapInterface> prq;
+
+    public MaxHeap(){
+        // ISO date is lexicographically comparable
+        final PriorityQueue<HeapInterface> prq = new PriorityQueue <> ((a, b)->{
+                final int r = a.line.compareTo(b.line);
+                if(r>0) return 1;
+                if(r<0) return -1;
+                return 0;
+        });
+        this.prq = prq;
+    }
+
+    public void add(FileHandler fh){
+        final String line = fh.readLine();
+        if(line == null) {
+            // indicates end of file
+            return;
+        };
+        final HeapInterface tuple = new HeapInterface(fh, line);
+        prq.offer(tuple);
+        return;
+    }
+
+    public String pop(){
+        final HeapInterface res = prq.poll();
+        if(res == null) {
+            // indicates end of heap
+            return null;
+        }
+        final FileHandler fh = res.fh;
+        final String line = res.line;
+        this.add(fh);// add next line
+        return line;
+    }
+
+}

--- a/src/main/kotlin/com/armory/logsort/generator/LogGenerator.kt
+++ b/src/main/kotlin/com/armory/logsort/generator/LogGenerator.kt
@@ -9,7 +9,10 @@ class LogGenerator(val fileCount: Int, val avgLineCount: Long) {
     fun generate(filePath: String) {
         File(filePath).mkdirs()
         val files = (0..fileCount).map { File("${filePath}log_$it.log") }
-        files.forEach { it.createNewFile() }
+        files.forEach {
+            it.delete()
+            it.createNewFile()
+        }
 
         var currentTs = Instant.ofEpochSecond(925543800L)
         val linesCountToGenerate = fileCount*avgLineCount

--- a/verifyResult.sh
+++ b/verifyResult.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+sort -c final.log
+if [ $? -eq 0 ]; then
+    echo OK
+else
+    echo FAIL
+fi


### PR DESCRIPTION
### Some of the difficulties found

- Guessed environment and build commands.
    - So many SDK versions for Java, just downloaded the latest and it worked  out fine but it made me a bit anxious to just pick blindly.
- Kotlin code for input files (the ones with the timestamps) mislead me for a while.
    - File generation aggregates and doesn’t truncate on re-run, that means that on a re-run you get files that aren’t really sorted ascendingly because you got the same data twice on 1 file.
- Had a bit of a difficult time figuring out how to test the memory constraint.
    - Settled for testing by indicating max heap size with `$ java -jar -Xmx512m ...`
- Some gradle commands that were useful and could go in the readme:
    
    ```jsx
    $ gradle tasks
    $ gradle clean build
    $ gradle bootRun
    ```
    

### Tech details

Built with gradle

```jsx
$ gradle -version
------------------------------------------------------------
Gradle 7.4.2
------------------------------------------------------------

Build time:   2022-03-31 15:25:29 UTC
Revision:     540473b8118064efcc264694cbcaa4b677f61041

Kotlin:       1.5.31
Groovy:       3.0.9
Ant:          Apache Ant(TM) version 1.10.11 compiled on July 10 2021
JVM:          18.0.1.1 (Homebrew 18.0.1.1+0)
OS:           Mac OS X 12.2.1 aarch64
```

Trying to run `gradlew` script did not work.

Ran the `.jar` with the following commands to make sure `-Xmx` option was a reliable way of figuring out if the files were loaded to memory or not:

```jsx
$ gradle build
$ java -jar -Xmx24m ./build/libs/logAggregation-0.0.1-SNAPSHOT.jar
$ java -jar -Xmx34m ./build/libs/logAggregation-0.0.1-SNAPSHOT.jar
```

Tested correctness of result with `$ sort -c final.log`

### Some decisions

- Changed result a little bit

Original asks for result to be displayed on the screen.

Instead result is added to a file, which allows a more ergonomic inspection of the result.

- Found `gradle test` but did not adjust the test to new implementation.
- At first I was going to use [[sort(1)](https://man7.org/linux/man-pages/man1/sort.1.html)](https://man7.org/linux/man-pages/man1/sort.1.html) since it already solves the k-way merge, ended up solving it with Java alone in order to have something more juicy to talk about.

### Additional

Some bash scripts provided at root folder for convenience.